### PR TITLE
Change MAXNC to 600 in bufrlib.h in order to sychronize the parameter

### DIFF
--- a/src/bufrlib.h
+++ b/src/bufrlib.h
@@ -119,7 +119,7 @@ void wrdlen( void );
 ** "bufrlib.PRM" for use by several FORTRAN routines.  See "bufrlib.PRM"
 ** for a description of these parameters.
 */
-#define MAXNC	300
+#define MAXNC	600
 #define MXMTBB	4000
 #define MXMTBD	1000
 #define MAXCD	250


### PR DESCRIPTION
settings in bufrlib.h and bufrlib.PRM.orig.